### PR TITLE
Small refactoring of webpack config

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,17 +10,23 @@ var rm = require('gulp-rimraf');
 var KarmaServer = require('karma').Server;
 var webpack = require("webpack");
 var WebpackDevServer = require("webpack-dev-server");
-var webpackConfig = require("./webpack.prod.config.js");
 var minimist = require('minimist');
 
 var knownOptions = {
-  string: 'buildNumber',
-  default: { buildNumber: 'LOCAL' }
+  string: [
+    'buildNumber',
+    'webpackConfig'
+  ],
+  default: {
+    buildNumber: 'LOCAL',
+    webpackConfig: './webpack.config.js'
+  }
 };
 
 var options = minimist(process.argv.slice(2), knownOptions);
 
-var versionMajorMinor = fs.readFileSync(__dirname + '/VERSION');
+var webpackConfig = require(options.webpackConfig)
+var versionMajorMinor = fs.readFileSync(__dirname + '/VERSION');;
 var gitHash = '';
 
 gulp.task("webpack-dev-server", function(callback) {

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,74 +1,30 @@
-var path = require('path');
-var webpack = require('webpack');
+var skyuxPackage = require('blackbaud-skyux/package.json');
+var skyuxSri = require('blackbaud-skyux/dist/sri.json');
+var webpackConfig = require('./webpack.config');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
-module.exports = {
-    entry: './app/app.js',
-    output: {
-        path: __dirname + '/dist',
-        filename: 'bundle.js'
-    },
-    module: {
-        preLoaders: [
-            {
-                test: /\.js$/,
-                loader: 'eslint-loader',
-                exclude: /node_modules/
-            }
-        ],
-        loaders: [
-            {
-                test: /\.js$/,
-                loader: 'ng-annotate?add=true!babel',
-                exclude: /node_modules/
-            },
-            {
-                test: /.html$/,
-                loader: 'ngtemplate?relativeTo=' + __dirname + '/app!html?root=' + __dirname + '/app'
-            },
-            {
-                test: /\.css$/,
-                loader: 'style-loader!css-loader'
-            },
-            {
-                test: /\.scss$/,
-                loaders: ['style', 'css?root=' + __dirname + '/app', 'autoprefixer-loader?browsers=last 2 versions', 'sass'],
-            },
-            {
-                test: /.(png|woff(2)?|eot|ttf|svg)(\?[a-z0-9=\.]+)?$/,
-                loader: 'url-loader?limit=1000000000'
-            }
-        ]
-    },
-    plugins: [
-        new webpack.optimize.DedupePlugin(),
-        new webpack.optimize.UglifyJsPlugin({minimize: false, output: {comments: false}}),
-        new webpack.ProvidePlugin(
-            {
-                $: 'jquery',
-                jQuery: 'jquery',
-                'window.jQuery': 'jquery'
-            }
-        ),
-        new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /de|fr|hu/),
-        new HtmlWebpackPlugin({
-            title: 'Custom Template',
-            template: './app/index_template.ejs',
-            inject: 'body',
-            skyCSS: '<link rel="stylesheet" href="https://sky.blackbaudcdn.net/skyux/1.6.4/css/sky-bundle.css" integrity="sha384-YJEM27yZzrxOT7raXkqGl5DAMP/0qKGf5H3BtWVxuJq1PMwn0GHVh9i7oX+ptm6R" crossorigin="anonymous">',
-            skyJS: '<script src="https://sky.blackbaudcdn.net/skyux/1.6.4/js/sky-bundle.min.js"></script>'
-        })
-    ],
-    externals: {
-        "blackbaud-skyux": 'var sky = "sky"'
-    },
-    resolve: {
-        root: path.resolve('app/'),
-        extensions: ['', '.js']
-    },
-    eslint: {
-        failOnError: true
-    },
-    sassLoader: {
-        includePaths: [path.resolve(__dirname, "./app")]
-    }
-};
+var format = require('util').format;
+
+const getCDN = (template, file) => {
+  const url = format(
+    'https://sky.blackbaudcdn.net/skyux/%s/%s',
+    skyuxPackage.version,
+    file
+  );
+  const integrity = format(
+    'integrity="%s" crossorigin="anonymous"',
+    skyuxSri['@dist/' + file].integrity
+  );
+  return format(template, url, integrity);
+}
+
+webpackConfig.plugins.push(
+  new HtmlWebpackPlugin({
+      title: 'Custom Template',
+      template: './app/index_template.ejs',
+      inject: 'body',
+      skyCSS: getCDN('<link rel="stylesheet" href="%s" %s>', 'css/sky-bundle.css'),
+      skyJS: getCDN('<script src="%s" %s></script>', 'js/sky-bundle.min.js')
+  })
+);
+
+module.exports = webpackConfig;


### PR DESCRIPTION
- Refactored `webpack.prod.config.js` to extend `webpack.config.js` settings.
- Having `webpack.prod.config.js` build the CSS/JS tags using the version and integrity values from SKYUX `package.json` and `sri.json`.
- Allowing `--webpackConfig=./webpack.prod.config.js` to be passed into gulp.
